### PR TITLE
Add Windows path instructions for docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Run docker: (Take care to personalize to where you pulled this repo)
 
 ``docker run --rm -it -v `pwd`:/workspace/ rwdougla/aq_cpp bash``
 
+If running Docker in Windows(specifically through Powershell), the `pwd` command above will need to be substituted with a path like the following:
+``docker run -it -v //d/Users/Username/Documents/repos/cpp_interview:"/workspace/" rwdougla/aq_cpp bash``
+
 Inside Docker container:
 
 ```


### PR DESCRIPTION
Hey @rwdougla, I found this repo through the Aquatic site and wanted to see if I could complete it independently. Sadly, the only test available was a single assert. Any chance you could add some more tests?

![image](https://user-images.githubusercontent.com/4118039/108395708-b0a03d00-71db-11eb-9715-31f628ffbaea.png)

Also, I ran into an issue that took me a few minutes to solve regarding mounting a local Windows path in the image. I made a minor change to your readme to help you prevent some user confusion.